### PR TITLE
use dummy boot to implement config

### DIFF
--- a/examples/nextjs/currents.config.js
+++ b/examples/nextjs/currents.config.js
@@ -1,6 +1,3 @@
 module.exports = {
   projectId: "IjH22B",
-  e2e: {
-    specPattern: "cypress/e2e/*.spec.js",
-  },
 };

--- a/examples/nextjs/cypress.config.ts
+++ b/examples/nextjs/cypress.config.ts
@@ -1,5 +1,6 @@
 const { defineConfig } = require("cypress");
 const { loadEnvConfig } = require("@next/env");
+const { currents } = require("cypress-runner/plugin");
 
 function loadEnvVariables() {
   const projectDir = process.cwd();
@@ -10,11 +11,13 @@ loadEnvVariables();
 // const projectId = process.env.CYPRESS_PROJECT_ID;
 
 module.exports = defineConfig({
-  // projectId,
   e2e: {
     supportFile: false,
-    specPattern: "cypress/e2e/*.spec.js",
+    specPattern: (function () {
+      return "cypress/e2e/*.spec.js";
+    })(),
     setupNodeEvents(on, config) {
+      currents(on, config);
       // implement node event listeners here
     },
   },

--- a/packages/cypress-runner/index.ts
+++ b/packages/cypress-runner/index.ts
@@ -36,13 +36,17 @@ export async function run() {
   const testingType: TestingType = options.component ? "component" : "e2e";
   const config = await getConfig(testingType);
 
+  console.log("Config", config);
+  // const port = getRandomPort();
+  // const server = await createWSServer(port);
+
   if (!config.projectId) {
     console.error("Missing projectId in config file");
     process.exit(1);
   }
 
   const specPattern = options.spec || config.specPattern;
-  console.log({ specPattern });
+
   const specs = await findSpecs({
     projectRoot: process.cwd(),
     testingType,
@@ -61,6 +65,7 @@ export async function run() {
   // I expect this to be a source of trouble untils we polish the implementation
   if (specs.length === 0) {
     console.error("No spec matching the spec pattern found");
+    // server.close();
     process.exit(0);
   }
 
@@ -103,6 +108,8 @@ export async function run() {
     machineId: run.machineId,
     platform,
   });
+
+  // server.close();
 }
 
 type InstanceRequestArgs = {
@@ -210,6 +217,28 @@ async function processCypressResults(
 
   await uploadStdout(instanceId, stdout.toString());
 }
+
+// function createWSServer(port: number) {
+//   // Create the WebSocket server
+//   const server = new WebSocket.Server({ port });
+
+//   // Listen for new connections
+//   server.on("connection", (socket: any) => {
+//     console.log("New connection!");
+
+//     socket.send("Hello from the server!");
+//     // Listen for messages from the client
+//     socket.on("message", (data: string) => {
+//       console.log(`Received message: ${data}`);
+//     });
+//   });
+
+//   server.on("close", () => {
+//     console.log("Server closed");
+//   });
+
+//   return server;
+// }
 
 run().catch((err) => {
   console.error(err);

--- a/packages/cypress-runner/lib/bootstrap.ts
+++ b/packages/cypress-runner/lib/bootstrap.ts
@@ -1,0 +1,30 @@
+import cp from "child_process";
+import { getBinPath } from "cy2";
+import fs from "fs";
+import { nanoid } from "nanoid";
+import { createTempFile } from "./fs";
+
+export const bootCypress = async (port: number) => {
+  const tempFilePath = await createTempFile();
+
+  // TODO: provide the same flags as for the command
+  const cypressBin = await getBinPath(require.resolve("cypress"));
+  cp.spawnSync(
+    cypressBin,
+    [
+      "run",
+      "--spec",
+      nanoid(),
+      "--env",
+      `currents_port=${port},currents_temp_file=${tempFilePath}`,
+    ],
+    {
+      stdio: "pipe",
+    }
+  );
+
+  if (!fs.existsSync(tempFilePath)) {
+    throw new Error("Cannot detect cypress config file");
+  }
+  return JSON.parse(fs.readFileSync(tempFilePath, "utf-8"));
+};

--- a/packages/cypress-runner/lib/config.ts
+++ b/packages/cypress-runner/lib/config.ts
@@ -1,5 +1,7 @@
 import path from "path";
 import { TestingType } from "../types";
+import { bootCypress } from "./bootstrap";
+import { getRandomPort } from "./utils";
 
 const getConfigFile = async (explicitLocation = null) => {
   if (explicitLocation) {
@@ -9,8 +11,11 @@ const getConfigFile = async (explicitLocation = null) => {
 };
 
 export const getConfig = async (testingType: TestingType) => {
+  const cypressConfigFile: Cypress.ResolvedConfigOptions = await bootCypress(
+    getRandomPort()
+  );
   const configFile = await getConfigFile();
-  let config = {};
+  let config: Record<string, unknown> = {};
   try {
     config = require(configFile);
   } catch (e) {
@@ -20,10 +25,25 @@ export const getConfig = async (testingType: TestingType) => {
     );
   }
 
+  // @ts-ignore
+  const rawE2EPattern = cypressConfigFile.rawJson?.e2e?.specPattern;
+  let additionalIgnorePattern: string[] = [];
+  if (testingType === "component" && rawE2EPattern) {
+    // @ts-ignore
+    additionalIgnorePattern = rawE2EPattern;
+  }
+  return {
+    projectId: config.projectId,
+    specPattern: cypressConfigFile.specPattern,
+    // @ts-ignore
+    excludeSpecPattern: cypressConfigFile.resolved.excludeSpecPattern.value,
+    additionalIgnorePattern,
+  };
+
   // see https://github.com/cypress-io/cypress/blob/ed0668e24c2ee6753bbd25ae467ce94ae5857741/packages/config/src/options.ts#L457
   // and https://github.com/cypress-io/cypress/blob/develop/packages/config/src/project/utils.ts#L412
 
-  let additionalIgnorePattern = [];
+  // let additionalIgnorePattern = [];
   // @ts-ignore
   if (testingType === "component" && config.e2e && config.e2e.specPattern) {
     // @ts-ignore

--- a/packages/cypress-runner/lib/fs.ts
+++ b/packages/cypress-runner/lib/fs.ts
@@ -1,0 +1,6 @@
+import { file } from "tmp-promise";
+
+export const createTempFile = async () => {
+  const { path } = await file();
+  return path;
+};

--- a/packages/cypress-runner/lib/utils.ts
+++ b/packages/cypress-runner/lib/utils.ts
@@ -7,3 +7,9 @@ export function toArray(val?: string | string[]) {
 export function toPosix(file: string, sep: string = path.sep) {
   return file.split(sep).join(path.posix.sep);
 }
+
+export const getRandomPort = () => {
+  const min = 1024;
+  const max = 65535;
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};

--- a/packages/cypress-runner/package.json
+++ b/packages/cypress-runner/package.json
@@ -16,7 +16,7 @@
     "@types/lodash": "^4.14.191",
     "@types/randomstring": "^1.1.8",
     "@types/stack-utils": "^2.0.1",
-    "cypress": "^12.0.2",
+    "@types/ws": "^8.5.3",
     "eslint": "^7.32.0",
     "eslint-config-custom": "*",
     "tsconfig": "*",
@@ -36,6 +36,8 @@
     "lodash": "^4.17.21",
     "nanoid": "^3.3.4",
     "randomstring": "^1.2.3",
-    "stack-utils": "^2.0.6"
+    "stack-utils": "^2.0.6",
+    "tmp-promise": "^3.0.3",
+    "ws": "^8.11.0"
   }
 }

--- a/packages/cypress-runner/plugin/index.ts
+++ b/packages/cypress-runner/plugin/index.ts
@@ -1,0 +1,32 @@
+import fs from "fs";
+
+const WebSocket = require("ws");
+
+// @ts-ignore
+export const currents = async (on, config) => {
+  // Create the WebSocket client
+
+  if (!config.env.currents_temp_file) {
+    console.warn(
+      "env.currents_temp_file is undefined, skipping currents setup"
+    );
+    return config;
+  }
+
+  fs.writeFileSync(config.env.currents_temp_file, JSON.stringify(config));
+
+  //   const client = new WebSocket(`ws://localhost:${config.env.currents_port}`);
+  //   client.on("close", () => {
+  //     console.log("client closed");
+  //   });
+  //   //@ts-ignore
+  //   client.on("error", (err) => {
+  //     console.log("error", err);
+  //   });
+  //   client.on("message", function incoming(data: string) {
+  //     console.log("Received message", data);
+  //   });
+  //   client.on("open", function open() {
+  //     client.send(JSON.stringify({ type: "config", payload: config }));
+  //   });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,6 +571,13 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
+"@types/ws@^8.5.3":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yauzl@^2.9.1":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
@@ -3267,7 +3274,14 @@ through@2, through@^2.3.8, through@~2.3, through@~2.3.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tmp@~0.2.1:
+tmp-promise@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
+tmp@^0.2.0, tmp@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
@@ -3534,6 +3548,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Launch cypress with a dummy config file. 

- requires configuring a plugin: https://github.com/currents-dev/cypress-cloud/compare/feat/use-cypress-dummy-boot-to-get-config?expand=1#diff-73bc8d4b10cc3ff7c615f65806631c77e95d029535a63fda7a3e75a20e974d3eR20
- when loaded, it will create a temp file with parsed cypress config