### PR TITLE
Get platform os information

### DIFF
--- a/packages/cypress-runner/index.ts
+++ b/packages/cypress-runner/index.ts
@@ -19,6 +19,7 @@ import {
   getCiParams,
   getCiProvider,
 } from "./lib/ciProvider";
+import { getPlatformInfo } from "./lib/platform";
 
 const stdout = capture.stdout();
 
@@ -78,9 +79,10 @@ export async function run() {
     process.exit(0);
   }
 
+  const osPlatformInfo = await getPlatformInfo();
+
   const platform = {
-    osName: "darwin",
-    osVersion: "22.1.0",
+    ...osPlatformInfo,
     browserName: "Electron",
     browserVersion: "106.0.5249.51",
   };

--- a/packages/cypress-runner/lib/platform.ts
+++ b/packages/cypress-runner/lib/platform.ts
@@ -1,0 +1,32 @@
+import { platform, release, cpus, freemem, totalmem } from "os";
+import { promisify } from "util";
+import getos from "getos";
+
+const getOsVersion = async () => {
+  if (platform() === "linux") {
+    try {
+      const linuxOs = await promisify(getos)();
+      if ("dist" in linuxOs && "release" in linuxOs) {
+        return [linuxOs.dist, linuxOs.release].join(" - ");
+      } else {
+        return release();
+      }
+    } catch {
+      return release();
+    }
+  }
+  return release();
+};
+
+export const getPlatformInfo = async () => {
+  const osVersion = await getOsVersion();
+  return {
+    osName: platform(),
+    osVersion,
+    osCpus: cpus(),
+    osMemory: {
+      free: freemem(),
+      total: totalmem(),
+    },
+  };
+};


### PR DESCRIPTION
This PR populates the OS platform information. The logic is ported from here: [https://github.com/cypress-io/cypress/blob/56234e52d6d1cbd292acdfd5f5d547f0c4706b51/packages/server/lib/util/system.js](https://github.com/cypress-io/cypress/blob/56234e52d6d1cbd292acdfd5f5d547f0c4706b51/packages/server/lib/util/system.js
)

The browserName and browserVersion still need to be populated.